### PR TITLE
Refactor SAST Triage Agent into modular architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # LiteLLM Proxy Configuration
 LLM_BASE_URL=http://localhost:4000
-LLM_MODEL=gemini-2.5-flash
+LLM_MODEL=gemini-2.5-pro
 LLM_API_KEY=sk-1234

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+CLAUDE.md
+.claude
+codebase
+findings
+
 # Environment and configuration
 .env
 *.local
@@ -60,6 +65,9 @@ triage_results.json
 # Test data (keep samples)
 findings/triage_list.csv
 findings/findings_details.json
+
+# Local notes
+local-notes/
 
 # Jupyter
 .ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -1,142 +1,62 @@
 # SAST Triage Agent
 
-Automated triage of Checkmarx SAST findings using LangChain and Google Gemini.
+Automated triage of Checkmarx SAST findings using LangChain and LLM.
 
 ## Setup
 
-### 1. Install Dependencies
-
 ```bash
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# Install dependencies
 pip install -r requirements.txt
-```
-
-### 2. Configure LLM Endpoint
-
-Set environment variables:
-```bash
-export LLM_BASE_URL='http://localhost:4000'
-export LLM_MODEL='gemini-2.5-pro'
-export LLM_API_KEY='dummy-key'
-```
-
-Or use `.env` file:
-```bash
 cp .env.example .env
-# Edit .env with your settings
+# Edit .env with your LLM endpoint settings
 ```
 
-### 3. Directory Structure
+## Directory Structure
 
-Your project directory should contain:
 ```
-my_project/
+project/
 ├── findings/
 │   ├── triage_list.csv
 │   └── findings_details.json  
 └── codebase/
-    └── (your source code)
-```
-
-After running the analysis, output is created:
-```
-my_project/
-├── findings/
-├── codebase/
-└── findings_assessment.json  ← created here
-```
-
-### 4. Input File Formats
-
-#### triage_list.csv
-```csv
-findingId,severity,triaged
-8ac6484c65c49772,HIGH,no
-9ui9316uww0i9e9j,HIGH,no
-```
-
-#### findings_details.json
-```json
-[
-    {
-        "findingId": "8ac6484c65c49772",
-        "category": "JavaScript_Angular",
-        "cweID": 79,
-        "languageName": "javascript",
-        "queryName": "Angular_Client_DOM_XSS",
-        "severity": "HIGH",
-        "dataflow": [
-            {
-                "column": "62",
-                "fileName": "/frontend/src/app/search-result.component.ts",
-                "line": "152",
-                "method": "filterTable",
-                "name": "q",
-                "nodeID": 1,
-                "domType": "source"
-            },
-            {
-                "column": "18",
-                "fileName": "/frontend/src/app/search-result.component.ts", 
-                "line": "160",
-                "method": "filterTable",
-                "name": "innerHTML",
-                "nodeID": 2,
-                "domType": "sink"
-            }
-        ]
-    }
-]
+    └── (source code)
 ```
 
 ## Usage
 
 ```bash
-# Use current directory
-python run_triage.py
-
-# Specify project directory
-python run_triage.py ./my_project
-
-# Use absolute path
-python run_triage.py /path/to/context
+python run_triage.py [project_directory]
 ```
 
-## Output Format
+Creates `findings_assessment.json` with triage decisions.
+
+## Input Format
+
+**triage_list.csv**:
+```csv
+findingId,severity,triaged
+8ac6484c65c49772,HIGH,no
+```
+
+**findings_details.json**:
+```json
+[{
+    "findingId": "8ac6484c65c49772",
+    "queryName": "Angular_Client_DOM_XSS", 
+    "severity": "HIGH",
+    "dataflow": [
+        {"fileName": "/app/file.ts", "line": "152", "domType": "source"},
+        {"fileName": "/app/file.ts", "line": "160", "domType": "sink"}
+    ]
+}]
+```
+
+## Output
 
 ```json
-[
-    {
-        "findingId": "8ac6484c65c49772",
-        "assessment_result": "CONFIRMED",
-        "assessment_confidence": 0.85,
-        "assessment_justification": "Detailed explanation..."
-    }
-]
+[{
+    "findingId": "8ac6484c65c49772",
+    "assessment_result": "CONFIRMED|NOT_EXPLOITABLE|REFUSED",
+    "assessment_confidence": 0.85,
+    "assessment_justification": "..."
+}]
 ```
-
-### Assessment Results
-
-- **CONFIRMED**: True positive vulnerability
-- **NOT_EXPLOITABLE**: False positive 
-- **REFUSED**: Insufficient information
-
-### Confidence Scores
-
-- **0.8-1.0**: High confidence
-- **0.5-0.79**: Medium confidence  
-- **0.0-0.49**: Low confidence
-
-## How It Works
-
-1. Parse CSV findings list and JSON details
-2. For each finding:
-   - Trace dataflow from source to sink
-   - Examine code at critical points
-   - Check for security controls
-   - Evaluate exploitation potential
-3. Generate structured assessment with confidence score

--- a/run_triage.py
+++ b/run_triage.py
@@ -25,7 +25,7 @@ load_dotenv()
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent))
 
-from sast_triage_agent import SASTTriageAgent
+from sast_triage import SASTTriageAgent
 
 
 def check_prerequisites():

--- a/sast_triage/__init__.py
+++ b/sast_triage/__init__.py
@@ -1,0 +1,32 @@
+"""
+SAST Triage Agent - Automated security analysis for Checkmarx findings
+"""
+
+from .agent import SASTTriageAgent
+from .models import TriageDecision
+from .config import (
+    CODEBASE_PATH, FINDINGS_PATH, DEFAULT_CSV_FILE, DEFAULT_JSON_FILE,
+    MAX_ANALYSIS_ITERATIONS, MAX_SEARCH_RESULTS, MAX_LOG_RESULT_LENGTH
+)
+from .tools import (
+    parse_csv_findings, get_finding_details, read_file, search_in_files,
+    submit_triage_decision, list_directory
+)
+
+__all__ = [
+    "SASTTriageAgent",
+    "TriageDecision", 
+    "CODEBASE_PATH",
+    "FINDINGS_PATH",
+    "DEFAULT_CSV_FILE", 
+    "DEFAULT_JSON_FILE",
+    "MAX_ANALYSIS_ITERATIONS",
+    "MAX_SEARCH_RESULTS", 
+    "MAX_LOG_RESULT_LENGTH",
+    "parse_csv_findings",
+    "get_finding_details",
+    "read_file",
+    "search_in_files", 
+    "submit_triage_decision",
+    "list_directory"
+]

--- a/sast_triage/config.py
+++ b/sast_triage/config.py
@@ -1,0 +1,14 @@
+"""
+Configuration constants for SAST Triage Agent
+"""
+
+# Path Configuration
+CODEBASE_PATH = "codebase"
+FINDINGS_PATH = "findings"
+DEFAULT_CSV_FILE = f"{FINDINGS_PATH}/triage_list.csv"
+DEFAULT_JSON_FILE = f"{FINDINGS_PATH}/findings_details.json"
+
+# Analysis Configuration
+MAX_ANALYSIS_ITERATIONS = 25  # Maximum iterations for LLM analysis per finding
+MAX_SEARCH_RESULTS = 10000    # Safety cap for search results (~500k tokens)
+MAX_LOG_RESULT_LENGTH = 5000  # Maximum length for logging tool results

--- a/sast_triage/logging_utils.py
+++ b/sast_triage/logging_utils.py
@@ -1,0 +1,115 @@
+"""
+Logging utilities for SAST Triage Agent
+"""
+
+import json
+import datetime
+from typing import Dict, List, Any
+from pathlib import Path
+
+from .models import TriageDecision
+from .config import MAX_LOG_RESULT_LENGTH
+
+
+class LoggingManager:
+    """Handles comprehensive logging for agent conversations."""
+    
+    def __init__(self, model_name: str, temperature: float):
+        """
+        Initialize the logging manager.
+        
+        Args:
+            model_name: Name of the model being used
+            temperature: Temperature setting of the model
+        """
+        self.model_name = model_name
+        self.temperature = temperature
+        self.setup_logging()
+    
+    def setup_logging(self):
+        """Setup comprehensive logging for agent conversations."""
+        # Create logs directory if it doesn't exist
+        log_dir = Path("logs")
+        log_dir.mkdir(exist_ok=True)
+        
+        # Create timestamped log file
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.log_file = log_dir / f"sast_triage_{timestamp}.json"
+        
+        # Initialize log structure
+        self.session_log = {
+            "session_start": datetime.datetime.now().isoformat(),
+            "model": self.model_name,
+            "temperature": self.temperature,
+            "findings_processed": []
+        }
+        
+        # Write initial log
+        self.save_log()
+    
+    def save_log(self):
+        """Save the current log state to file."""
+        try:
+            with open(self.log_file, 'w') as f:
+                json.dump(self.session_log, f, indent=2, default=str)
+        except Exception as e:
+            print(f"Warning: Could not save log: {e}")
+    
+    def log_finding_start(self, finding_id: str) -> Dict:
+        """Start logging a new finding analysis."""
+        finding_log = {
+            "finding_id": finding_id,
+            "start_time": datetime.datetime.now().isoformat(),
+            "conversation": [],
+            "final_decision": None,
+            "end_time": None,
+            "duration_seconds": None
+        }
+        self.session_log["findings_processed"].append(finding_log)
+        return finding_log
+    
+    def log_message(self, finding_log: Dict, message_type: str, content: Any, tool_calls: List = None):
+        """Log a message in the conversation."""
+        log_entry = {
+            "type": message_type,
+            "timestamp": datetime.datetime.now().isoformat(),
+            "content": content
+        }
+        
+        if tool_calls:
+            log_entry["tool_calls"] = tool_calls
+        
+        finding_log["conversation"].append(log_entry)
+        
+        # Save incrementally
+        self.save_log()
+    
+    def log_tool_result(self, finding_log: Dict, tool_name: str, tool_args: Dict, result: Any):
+        """Log a tool execution result."""
+        log_entry = {
+            "type": "tool_result",
+            "timestamp": datetime.datetime.now().isoformat(),
+            "tool": tool_name,
+            "args": tool_args,
+            "result": str(result)[:MAX_LOG_RESULT_LENGTH]  # Truncate very long results for logging
+        }
+        
+        finding_log["conversation"].append(log_entry)
+        
+        # Save incrementally
+        self.save_log()
+    
+    def log_finding_complete(self, finding_log: Dict, decision: TriageDecision):
+        """Complete logging for a finding."""
+        finding_log["end_time"] = datetime.datetime.now().isoformat()
+        
+        # Calculate duration
+        start = datetime.datetime.fromisoformat(finding_log["start_time"])
+        end = datetime.datetime.fromisoformat(finding_log["end_time"])
+        finding_log["duration_seconds"] = (end - start).total_seconds()
+        
+        # Add final decision
+        finding_log["final_decision"] = decision.dict() if decision else None
+        
+        # Save final state
+        self.save_log()

--- a/sast_triage/models.py
+++ b/sast_triage/models.py
@@ -1,0 +1,13 @@
+"""
+Pydantic models for SAST Triage Agent
+"""
+
+from pydantic import BaseModel, Field
+
+
+class TriageDecision(BaseModel):
+    """Structured output for triage decisions matching Checkmarx format"""
+    findingId: str = Field(description="Unique identifier for the finding")
+    assessment_result: str = Field(description="CONFIRMED, NOT_EXPLOITABLE, or REFUSED")
+    assessment_confidence: float = Field(description="Confidence score between 0 and 1")
+    assessment_justification: str = Field(description="Detailed justification for the decision")

--- a/sast_triage/tools.py
+++ b/sast_triage/tools.py
@@ -1,0 +1,221 @@
+"""
+Tool definitions for SAST Triage Agent
+"""
+
+import os
+import csv
+import json
+import re
+import glob
+from typing import Dict, List
+
+from langchain_core.tools import tool
+
+from .config import CODEBASE_PATH, DEFAULT_CSV_FILE, DEFAULT_JSON_FILE, MAX_SEARCH_RESULTS
+
+
+@tool
+def parse_csv_findings(file_path: str = DEFAULT_CSV_FILE) -> List[Dict]:
+    """
+    Parse the CSV file containing SAST findings list.
+    
+    Args:
+        file_path: Path to the CSV file with findingId, severity, triaged columns
+    
+    Returns:
+        List of finding records from CSV
+    """
+    try:
+        findings = []
+        with open(file_path, 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row['triaged'].lower() == 'no':
+                    findings.append({
+                        'findingId': row['findingId'],
+                        'severity': row['severity'],
+                        'triaged': row['triaged']
+                    })
+        return findings
+    except Exception as e:
+        return [{"error": f"Failed to parse CSV: {str(e)}"}]
+
+
+@tool
+def get_finding_details(finding_id: str, json_path: str = DEFAULT_JSON_FILE) -> Dict:
+    """
+    Get detailed information for a specific finding from JSON file.
+    
+    Args:
+        finding_id: The finding ID to look up
+        json_path: Path to the JSON file with detailed findings
+    
+    Returns:
+        Detailed finding information including dataflow
+    """
+    try:
+        with open(json_path, 'r', encoding='utf-8') as f:
+            all_findings = json.load(f)
+        
+        for finding in all_findings:
+            if finding['findingId'] == finding_id:
+                return finding
+        
+        return {"error": f"Finding {finding_id} not found in details"}
+    except Exception as e:
+        return {"error": f"Failed to get finding details: {str(e)}"}
+
+
+@tool
+def read_file(file_path: str) -> Dict:
+    """
+    Read an entire file from the codebase.
+    
+    Args:
+        file_path: Path to the file relative to codebase
+    
+    Returns:
+        Complete file contents with line numbers
+    """
+    try:
+        full_path = os.path.join(CODEBASE_PATH, file_path.lstrip('/'))
+        
+        if not os.path.exists(full_path):
+            return {"error": f"File not found: {full_path}"}
+        
+        with open(full_path, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+        
+        # No limit - modern LLMs have huge context windows
+        result = {
+            'file': file_path,
+            'total_lines': len(lines),
+            'content': []
+        }
+        
+        for i, line in enumerate(lines):
+            result['content'].append(f"{i+1:5}: {line.rstrip()}")
+        
+        return result
+    except Exception as e:
+        return {"error": f"Failed to read file: {str(e)}"}
+
+
+@tool
+def search_in_files(pattern: str, file_extension: str) -> Dict:
+    """
+    Search for a pattern in files within the codebase.
+    
+    Args:
+        pattern: String or regex to search for
+        file_extension: File extension to search (e.g. "py", "js", "ts")
+    
+    Returns:
+        Search results with file paths and matching lines
+    """
+    try:
+        results = []
+        file_pattern = f"*.{file_extension}"
+        search_path = os.path.join(CODEBASE_PATH, "**", file_pattern)
+        files = glob.glob(search_path, recursive=True)
+        
+        pattern_re = re.compile(pattern, re.IGNORECASE)
+        max_results = MAX_SEARCH_RESULTS  # Safety cap: ~500k tokens worth of results
+        
+        for file_path in files:  # Search ALL files, no limit
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    lines = f.readlines()
+                    for i, line in enumerate(lines):
+                        if pattern_re.search(line):
+                            rel_path = os.path.relpath(file_path, CODEBASE_PATH)
+                            results.append({
+                                'file': rel_path,
+                                'line': i + 1,
+                                'content': line.strip()
+                            })
+                            if len(results) >= max_results:
+                                break
+                if len(results) >= max_results:
+                    break
+            except:
+                continue
+        
+        return {
+            'pattern': pattern,
+            'file_extension': file_extension,
+            'matches_found': len(results),
+            'results': results
+        }
+    except Exception as e:
+        return {"error": f"Search failed: {str(e)}"}
+
+
+@tool
+def submit_triage_decision(
+    is_exploitable: bool,
+    confidence: float,
+    justification: str
+) -> Dict:
+    """
+    Submit the final triage decision after completing analysis.
+    
+    Args:
+        is_exploitable: True if the vulnerability is exploitable, False if not
+        confidence: Confidence level between 0.0 and 1.0
+        justification: Detailed explanation of the decision
+    
+    Returns:
+        Confirmation of decision submission
+    """
+    # Validate confidence is in range
+    if not 0.0 <= confidence <= 1.0:
+        return {"error": f"Confidence must be between 0.0 and 1.0, got {confidence}"}
+    
+    # Convert boolean to assessment result
+    assessment_result = "CONFIRMED" if is_exploitable else "NOT_EXPLOITABLE"
+    
+    return {
+        "status": "decision_submitted",
+        "assessment_result": assessment_result,
+        "confidence": confidence,
+        "justification": justification
+    }
+
+
+@tool
+def list_directory(directory_path: str) -> Dict:
+    """
+    List files and directories in a given path within the codebase.
+    
+    Args:
+        directory_path: Path relative to codebase (use "." for root)
+    
+    Returns:
+        List of files and directories
+    """
+    try:
+        if directory_path == ".":
+            full_path = CODEBASE_PATH
+        else:
+            full_path = os.path.join(CODEBASE_PATH, directory_path.lstrip('/'))
+        
+        if not os.path.exists(full_path):
+            return {"error": f"Directory not found: {full_path}"}
+        
+        items = []
+        for item in os.listdir(full_path):
+            item_path = os.path.join(full_path, item)
+            items.append({
+                'name': item,
+                'type': 'directory' if os.path.isdir(item_path) else 'file',
+                'size': os.path.getsize(item_path) if os.path.isfile(item_path) else None
+            })
+        
+        return {
+            'directory': directory_path,
+            'total_items': len(items),
+            'items': sorted(items, key=lambda x: (x['type'], x['name']))
+        }
+    except Exception as e:
+        return {"error": f"Failed to list directory: {str(e)}"}


### PR DESCRIPTION
- Split monolithic 761-line file into focused modules under 500 lines each
- Created sast_triage package with agent, tools, config, models, logging_utils modules
- Moved hardcoded magic numbers to configuration constants
- Added comprehensive logging system for audit trails
- Implemented tool-based decision submission replacing regex parsing
- Updated README to be concise and focused on essentials
- Removed redundant sast_triage_agent.py wrapper file
- Maintained backward compatibility and all existing functionality