### PR TITLE
Add testing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ findingId,severity,triaged
     "assessment_justification": "..."
 }]
 ```
+
+## Testing
+
+Run the test suite:
+```bash
+python -m pytest tests/
+```
+
+The test suite includes security tests, tool functionality tests and end-to-end integration tests.


### PR DESCRIPTION
Add brief testing documentation to README:
- Instructions for running the test suite with pytest
- Overview of test coverage including security, tools, and integration tests
- Maintains the concise style of the existing README