### PR TITLE
refactor: improve HTML report with timestamps and Checkmarx links

### DIFF
--- a/run_triage.py
+++ b/run_triage.py
@@ -73,13 +73,16 @@ def save_findings_data(
     print("✓ Findings data saved successfully")
 
 
-async def run_triage_analysis(output_dir: Path, project_id: str = None) -> int:
+async def run_triage_analysis(output_dir: Path, project_id: str = None, 
+                             scan_id: str = None, checkmarx_base_url: str = None) -> int:
     """
     Run the triage analysis on the fetched data.
     
     Args:
         output_dir: Directory containing the analysis data
         project_id: Project identifier for reporting
+        scan_id: Scan identifier for reporting
+        checkmarx_base_url: Checkmarx base URL for report links
     
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -107,7 +110,9 @@ async def run_triage_analysis(output_dir: Path, project_id: str = None) -> int:
             model_name=llm_model,
             api_key=llm_api_key,
             temperature=0.1,
-            project_id=project_id
+            project_id=project_id,
+            scan_id=scan_id,
+            checkmarx_base_url=checkmarx_base_url
         )
         
         results = await agent.process_all_findings()
@@ -116,7 +121,7 @@ async def run_triage_analysis(output_dir: Path, project_id: str = None) -> int:
         print("\n✓ Analysis complete!")
         print(f"Results saved to: findings_assessment.json")
         print(f"Updated CSV: findings/triage_list.csv")
-        print(f"HTML Report: triage_report.html")
+        print(f"HTML Report: Generated with timestamp")
         
         return 0
         
@@ -228,7 +233,7 @@ def main(
         print("Starting Triage Analysis")
         print("=" * 60)
         
-        exit_code = asyncio.run(run_triage_analysis(output_path, project_id))
+        exit_code = asyncio.run(run_triage_analysis(output_path, project_id, scan_id, base_url))
         
         # Clean up repository if requested
         if clean and codebase_dir.exists():

--- a/sast_triage/agent.py
+++ b/sast_triage/agent.py
@@ -28,7 +28,9 @@ class SASTTriageAgent:
         model_name: str = "gemini-2.5-pro", 
         api_key: str = "dummy-key",
         temperature: float = 0.1,
-        project_id: Optional[str] = None
+        project_id: Optional[str] = None,
+        scan_id: Optional[str] = None,
+        checkmarx_base_url: Optional[str] = None
     ):
         """
         Initialize the SAST Triage Agent.
@@ -39,8 +41,12 @@ class SASTTriageAgent:
             api_key: API key (can be dummy for local proxies)
             temperature: Model temperature for consistency
             project_id: Project identifier for reporting
+            scan_id: Scan identifier for reporting
+            checkmarx_base_url: Checkmarx base URL for report links
         """
         self.project_id = project_id
+        self.scan_id = scan_id
+        self.checkmarx_base_url = checkmarx_base_url
         self.llm = ChatOpenAI(
             base_url=base_url,
             model=model_name,
@@ -390,7 +396,9 @@ class SASTTriageAgent:
         from sast_triage.report_generator import ReportGenerator
         report_gen = ReportGenerator(
             output_dir=".",
-            project_id=self.project_id or "Unknown"
+            project_id=self.project_id or "Unknown",
+            scan_id=self.scan_id,
+            base_url=self.checkmarx_base_url
         )
         
         # Load all finding details for report
@@ -481,7 +489,7 @@ class SASTTriageAgent:
         with open('findings_assessment.json', 'w') as f:
             json.dump(triage_results, f, indent=2)
         
-        print(f"\n✓ HTML report generated: triage_report.html")
+        print(f"\n✓ HTML report generated: {report_gen.report_path.name}")
         
         # Generate summary for display
         summary = {

--- a/sast_triage/report_generator.py
+++ b/sast_triage/report_generator.py
@@ -10,17 +10,26 @@ from typing import Dict, Optional, List
 class ReportGenerator:
     """Generate progressive HTML reports for SAST findings."""
     
-    def __init__(self, output_dir: str = ".", project_id: Optional[str] = None):
+    def __init__(self, output_dir: str = ".", project_id: Optional[str] = None, 
+                 scan_id: Optional[str] = None, base_url: Optional[str] = None):
         """
         Initialize the report generator.
         
         Args:
             output_dir: Directory to save the report
             project_id: Project identifier for the report
+            scan_id: Scan identifier for the report
+            base_url: Checkmarx base URL for generating links
         """
         self.output_dir = Path(output_dir)
         self.project_id = project_id or "Unknown"
-        self.report_path = self.output_dir / "triage_report.html"
+        self.scan_id = scan_id
+        self.base_url = base_url
+        
+        # Generate timestamp-based filename
+        timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+        filename = f"{timestamp}_triage_report_{self.project_id}.html"
+        self.report_path = self.output_dir / filename
         self.findings_data = []
         self.stats = {
             "total": 0,
@@ -65,18 +74,23 @@ class ReportGenerator:
             <h1 class="text-3xl font-bold text-gray-800 mb-4">SAST Triage Report</h1>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                 <div>
-                    <span class="font-semibold">Project ID:</span> {self.project_id}
+                    <span class="font-semibold">Project ID:</span> 
+                    {f'<a href="{self.base_url}/projects/{self.project_id}" target="_blank" class="text-blue-600 hover:underline">{self.project_id}</a>' if self.base_url else self.project_id}
                 </div>
                 <div>
                     <span class="font-semibold">Analysis Date:</span> {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
                 </div>
             </div>
+            {f'''<div class="text-sm mt-2">
+                <span class="font-semibold">Scan ID:</span> 
+                <a href="{self.base_url}/sast-results/{self.project_id}/{self.scan_id}" target="_blank" class="text-blue-600 hover:underline">{self.scan_id}</a>
+            </div>''' if self.scan_id and self.base_url else ''}
             
             <!-- Statistics -->
             <div class="mt-4 grid grid-cols-2 md:grid-cols-4 gap-4" id="stats">
                 <div class="bg-gray-100 p-3 rounded">
                     <div class="text-2xl font-bold text-gray-700" id="stat-total">{total_findings}</div>
-                    <div class="text-xs text-gray-600">Total Findings</div>
+                    <div class="text-xs text-gray-600">Total Findings Analyzed</div>
                 </div>
                 <div class="bg-red-50 p-3 rounded">
                     <div class="text-2xl font-bold text-red-600" id="stat-confirmed">0</div>

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -16,7 +16,9 @@ class TestReportGenerator(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp()
         self.report_gen = ReportGenerator(
             output_dir=self.test_dir,
-            project_id="TEST-123"
+            project_id="TEST-123",
+            scan_id="SCAN-456",
+            base_url="https://checkmarx.example.com"
         )
     
     def tearDown(self):
@@ -29,8 +31,10 @@ class TestReportGenerator(unittest.TestCase):
         """Test report initialization."""
         self.report_gen.initialize_report(total_findings=5)
         
-        report_path = Path(self.test_dir) / "triage_report.html"
-        self.assertTrue(report_path.exists())
+        # Report path should have timestamp format
+        report_files = list(Path(self.test_dir).glob("*_triage_report_*.html"))
+        self.assertEqual(len(report_files), 1)
+        report_path = report_files[0]
         
         # Check content
         with open(report_path, 'r') as f:
@@ -38,8 +42,12 @@ class TestReportGenerator(unittest.TestCase):
         
         self.assertIn("TEST-123", content)
         self.assertIn("SAST Triage Report", content)
-        self.assertIn("Total Findings", content)
+        self.assertIn("Total Findings Analyzed", content)
         self.assertIn("5", content)
+        # Check for links
+        self.assertIn("https://checkmarx.example.com/projects/TEST-123", content)
+        self.assertIn("SCAN-456", content)
+        self.assertIn("https://checkmarx.example.com/sast-results/TEST-123/SCAN-456", content)
     
     def test_add_finding(self):
         """Test adding a finding to report."""
@@ -79,7 +87,10 @@ class TestReportGenerator(unittest.TestCase):
             total=1
         )
         
-        report_path = Path(self.test_dir) / "triage_report.html"
+        # Get the generated report file
+        report_files = list(Path(self.test_dir).glob("*_triage_report_*.html"))
+        self.assertEqual(len(report_files), 1)
+        report_path = report_files[0]
         with open(report_path, 'r') as f:
             content = f.read()
         
@@ -170,7 +181,10 @@ class TestReportGenerator(unittest.TestCase):
             total=1
         )
         
-        report_path = Path(self.test_dir) / "triage_report.html"
+        # Get the generated report file
+        report_files = list(Path(self.test_dir).glob("*_triage_report_*.html"))
+        self.assertEqual(len(report_files), 1)
+        report_path = report_files[0]
         with open(report_path, 'r') as f:
             content = f.read()
         


### PR DESCRIPTION
- Change report filename to YYYYMMDDHHMMSS_triage_report_projectid.html
- Update "Total Findings" label to "Total Findings Analyzed"
- Add clickable project ID link to Checkmarx project page
- Add scan ID with link to SAST results page
- Pass scan_id and base_url through entire chain from API to report
- Update agent and run_triage to handle new parameters
- Update tests to validate new report format and links