### PR TITLE
Remove unnecessary --skip-clone and --clean CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ REFRESH_TOKEN=refresh-token
 
 # LiteLLM Proxy Configuration
 LLM_BASE_URL=http://localhost:4000
-LLM_MODEL=gemini-2.0-flash-exp
+LLM_MODEL=gemini-2.5-pro
 LLM_API_KEY=sk-1234
 ```
 
@@ -34,15 +34,11 @@ python run_triage.py PROJECT_ID [OPTIONS]
 python run_triage.py 12345                           # Analyze project with default settings
 python run_triage.py 12345 --severities HIGH         # Only HIGH severity findings
 python run_triage.py 12345 --output-dir ./analysis  # Custom output directory
-python run_triage.py 12345 --skip-clone              # Skip repository cloning
-python run_triage.py 12345 --clean                   # Remove cloned repo after analysis
 ```
 
 Options:
 - `--severities`: Comma-separated severities (default: HIGH,MEDIUM)
 - `--output-dir`: Output directory (default: current directory)
-- `--skip-clone`: Skip repository cloning
-- `--clean`: Remove cloned repository after analysis
 
 ## Output Structure
 

--- a/run_triage.py
+++ b/run_triage.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from sast_triage import SASTTriageAgent
 from sast_triage.api import CheckmarxClient
-from sast_triage.git import clone_repository, cleanup_repository
+from sast_triage.git import clone_repository
 from sast_triage.config import DEFAULT_SEVERITIES
 
 
@@ -147,22 +147,10 @@ async def run_triage_analysis(output_dir: Path, project_id: str = None,
     default=".",
     help="Output directory for results (default: current directory)"
 )
-@click.option(
-    "--skip-clone",
-    is_flag=True,
-    help="Skip repository cloning"
-)
-@click.option(
-    "--clean",
-    is_flag=True,
-    help="Remove cloned repository after analysis"
-)
 def main(
     project_id: str,
     severities: str,
-    output_dir: str,
-    skip_clone: bool,
-    clean: bool
+    output_dir: str
 ) -> None:
     """
     Fetch SAST findings from Checkmarx One and run triage analysis.
@@ -201,9 +189,7 @@ def main(
         client = CheckmarxClient(base_url, refresh_token)
         
         # Get project details and repository URL
-        repo_url = None
-        if not skip_clone:
-            repo_url = client.get_project_details(project_id)
+        repo_url = client.get_project_details(project_id)
         
         # Get findings
         scan_id, findings = client.get_findings_for_project(project_id, severity_list)
@@ -218,13 +204,11 @@ def main(
         # Save findings data
         save_findings_data(findings_dir, triage_records, detailed_records)
         
-        # Clone repository if URL available and not skipped
-        if repo_url and not skip_clone:
+        # Clone repository if URL available
+        if repo_url:
             clone_success = clone_repository(repo_url, str(codebase_dir))
             if not clone_success:
                 print("⚠ Warning: Repository cloning failed, continuing with analysis...")
-        elif skip_clone:
-            print("\nSkipping repository clone as requested.")
         else:
             print("\n⚠ No repository URL found, continuing without codebase.")
         
@@ -234,11 +218,6 @@ def main(
         print("=" * 60)
         
         exit_code = asyncio.run(run_triage_analysis(output_path, project_id, scan_id, base_url))
-        
-        # Clean up repository if requested
-        if clean and codebase_dir.exists():
-            print("\nCleaning up cloned repository...")
-            cleanup_repository(str(codebase_dir))
         
         sys.exit(exit_code)
         

--- a/sast_triage/git/__init__.py
+++ b/sast_triage/git/__init__.py
@@ -1,5 +1,5 @@
 """Git repository management module."""
 
-from .repo_manager import clone_repository, cleanup_repository
+from .repo_manager import clone_repository
 
-__all__ = ["clone_repository", "cleanup_repository"]
+__all__ = ["clone_repository"]

--- a/sast_triage/git/repo_manager.py
+++ b/sast_triage/git/repo_manager.py
@@ -74,31 +74,3 @@ def clone_repository(
     except Exception as e:
         print(f"ERROR: Unexpected error while cloning: {e}")
         return False
-
-
-def cleanup_repository(target_dir: str) -> bool:
-    """
-    Remove the cloned repository directory.
-    
-    Args:
-        target_dir: The directory to remove
-        
-    Returns:
-        True if successful, False otherwise
-    """
-    target_path = Path(target_dir)
-    
-    if not target_path.exists():
-        print(f"Directory {target_dir} does not exist, nothing to clean.")
-        return True
-    
-    print(f"Cleaning up repository at {target_dir}...")
-    
-    try:
-        shutil.rmtree(target_path)
-        print("Repository cleaned up successfully.")
-        return True
-        
-    except Exception as e:
-        print(f"ERROR: Failed to clean up repository: {e}")
-        return False

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import patch, Mock, MagicMock
 import subprocess
 
-from sast_triage.git import clone_repository, cleanup_repository
+from sast_triage.git import clone_repository
 
 
 class TestGitRepository(unittest.TestCase):
@@ -94,32 +94,6 @@ class TestGitRepository(unittest.TestCase):
         
         self.assertTrue(result)  # Should return True (directory exists)
     
-    def test_cleanup_repository_success(self):
-        """Test successful repository cleanup."""
-        # Create a test directory
-        os.makedirs(self.target_dir)
-        Path(os.path.join(self.target_dir, "test.txt")).touch()
-        
-        result = cleanup_repository(self.target_dir)
-        
-        self.assertTrue(result)
-        self.assertFalse(os.path.exists(self.target_dir))
-    
-    def test_cleanup_repository_not_exists(self):
-        """Test cleanup when directory doesn't exist."""
-        result = cleanup_repository(self.target_dir)
-        
-        self.assertTrue(result)  # Should return True (nothing to clean)
-    
-    @patch("shutil.rmtree")
-    def test_cleanup_repository_error(self, mock_rmtree):
-        """Test cleanup with error."""
-        os.makedirs(self.target_dir)
-        mock_rmtree.side_effect = PermissionError("Permission denied")
-        
-        result = cleanup_repository(self.target_dir)
-        
-        self.assertFalse(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Removed --skip-clone option as analysis requires codebase access
- Removed --clean option to simplify code (users can manually delete if needed)
- Removed cleanup_repository function and all related tests
- Updated README documentation
- Simplified clone logic to always attempt cloning when URL available