### PR TITLE
Fix agent stuck iterations by enforcing tool usage

### DIFF
--- a/sast_triage/agent.py
+++ b/sast_triage/agent.py
@@ -115,7 +115,15 @@ class SASTTriageAgent:
         Do NOT re-read files you have already accessed - the complete file content is already available 
         in the conversation above. Re-reading the same file is wasteful and unnecessary.
         
-        IMPORTANT: When you have completed your analysis and are ready to provide your final assessment,
+        MANDATORY: You MUST use a tool in EVERY response. Choose one of:
+        - read_file: Read source code files
+        - search_in_files: Search for patterns across codebase  
+        - list_directory: Explore directory structure
+        - submit_triage_decision: Submit your final assessment
+        
+        DO NOT respond with text only - all responses must include tool usage.
+        
+        When you have completed your analysis and are ready to provide your final assessment,
         use the 'submit_triage_decision' tool with:
         - is_exploitable: true/false based on your analysis
         - confidence: your confidence level (0.0 to 1.0)
@@ -261,12 +269,10 @@ class SASTTriageAgent:
                         )
                         messages.append(tool_message)
                 else:
-                    # No tool calls - check if we need to prompt for decision
-                    if iteration == max_iterations - 1:
-                        # Last iteration, prompt for decision
-                        prompt = "Please use the submit_triage_decision tool to provide your final assessment."
-                        messages.append(("human", prompt))
-                        self.logger.log_message(finding_log, "human", prompt)
+                    # No tool calls - force tool usage immediately
+                    prompt = "You must use a tool. Either continue investigating with read_file/search_in_files/list_directory, or submit your final decision with submit_triage_decision."
+                    messages.append(("human", prompt))
+                    self.logger.log_message(finding_log, "human", prompt)
             
             # If we reach here, no decision was submitted via tool
             print(f"  Warning: No decision submitted after {max_iterations} iterations")


### PR DESCRIPTION
- Added mandatory tool usage instruction in system prompt
- Simplified iteration logic to immediately prompt for tool usage
- Removed complex last-iteration check logic
- Prevents agent from providing text-only responses that waste iterations
- Forces decisive action: investigate with tools or submit decision

Fixes issue where agent would provide reasoning text but forget to call submit_triage_decision tool, leading to empty iterations and REFUSED results.